### PR TITLE
Fixed bug in twitter.py on Windows. #1

### DIFF
--- a/semiphemeral/twitter.py
+++ b/semiphemeral/twitter.py
@@ -684,7 +684,7 @@ class Twitter(object):
                             )
                             click.echo(
                                 "Current time: {}".format(
-                                    time.strftime("%b %d, %Y %l:%M%p %Z")
+                                    time.strftime("%b %d, %Y %I:%M%p %Z")
                                 )
                             )
                             click.secho("Waiting 24 hours...", bold=True)


### PR DESCRIPTION
## Pull Request Title

Fix bug in `twitter.py`

## Description

This pull request fixes a bug in the `tweet.py` file that was causing an error when running the script on Windows. The error occurred when trying to display the current time using the `click.echo()` and `time.strftime()` function and the `%l` (lower case L) format code. On Windows, the `%l` (lower case L) code does not display the hour value in 12-hour format as expected. Instead, it displays a space character instead of the hour value.

To fix this issue, I replaced the `%l` (lower case L) code with `%I` (uppercase i) to display the hour value in 12-hour format. I have tested the changes on both Windows and Linux and verified that the script now displays the correct time format on both platforms.

## Changes Made

- Replace `%l` (lower case L) with `%I` (uppercase i) in `click.echo()` function to display the hour value in 12-hour format on Windows.
- Tested changes on both Windows and Linux.

## Screenshots

![image](https://user-images.githubusercontent.com/34519837/225625809-dc4bb602-9c6c-461f-a28e-fe3eb280e8bd.png)
